### PR TITLE
Proposed CONTRIBUTING.md file linking to a centrally maintained guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guide
+
+Our contributing guide is maintained at: https://unity-sds.gitbook.io/docs/get-involved/contributing-guide


### PR DESCRIPTION
## Purpose
- Changed CONTRIBUTING.md file format that points to a [centrally maintained Contributing Guide](https://unity-sds.gitbook.io/docs/get-involved/contributing-guide)
- Leveraging https://nasa-ammos.github.io/slim/documentation/starter-kits/#contributing-guide-template
## Proposed Changes
- [CHANGE] CONTRIBUTING.md file
## Testing
* For live example, see: https://github.com/unity-sds/unity-docs/blob/main/CONTRIBUTING.md
