### PR TITLE
220 stage in task

### DIFF
--- a/demos/cwl_dag_modular_stage_in.cwl
+++ b/demos/cwl_dag_modular_stage_in.cwl
@@ -16,7 +16,6 @@ requirements:
       PARALLEL_COUNT: '-1'
       DOWNLOAD_RETRY_WAIT_TIME: '30'
       DOWNLOAD_RETRY_TIMES: '5'
-      DOWNLOADING_ROLES: 'data'
 
       EDL_BASE_URL: 'https://urs.earthdata.nasa.gov/'
       EDL_USERNAME: '/sps/processing/workflows/edl_username'

--- a/demos/cwl_dag_modular_stage_in.cwl
+++ b/demos/cwl_dag_modular_stage_in.cwl
@@ -16,6 +16,7 @@ requirements:
       PARALLEL_COUNT: '-1'
       DOWNLOAD_RETRY_WAIT_TIME: '30'
       DOWNLOAD_RETRY_TIMES: '5'
+      DOWNLOADING_ROLES: 'data'
 
       EDL_BASE_URL: 'https://urs.earthdata.nasa.gov/'
       EDL_USERNAME: '/sps/processing/workflows/edl_username'

--- a/demos/cwl_dag_modular_stage_in.cwl
+++ b/demos/cwl_dag_modular_stage_in.cwl
@@ -1,0 +1,39 @@
+cwlVersion: v1.2
+class: CommandLineTool
+
+baseCommand: ["DOWNLOAD"]
+
+requirements:
+  DockerRequirement:
+    dockerPull: ghcr.io/unity-sds/unity-data-services:9.1.0
+  NetworkAccess:
+    networkAccess: true
+  EnvVarRequirement:
+    envDef:
+      DOWNLOAD_DIR: $(runtime.outdir)/$(inputs.download_dir)
+      STAC_JSON: $(inputs.stac_json)
+      LOG_LEVEL: '10'
+      PARALLEL_COUNT: '-1'
+      DOWNLOAD_RETRY_WAIT_TIME: '30'
+      DOWNLOAD_RETRY_TIMES: '5'
+      DOWNLOADING_ROLES: 'data'
+
+      EDL_BASE_URL: 'https://urs.earthdata.nasa.gov/'
+      EDL_USERNAME: '/sps/processing/workflows/edl_username'
+      EDL_PASSWORD: '/sps/processing/workflows/edl_password'
+      EDL_PASSWORD_TYPE: 'PARAM_STORE'
+
+      VERIFY_SSL: 'TRUE'
+      STAC_AUTH_TYPE: 'NONE'
+
+inputs:
+  download_dir:
+    type: string
+  stac_json:
+    type: string
+
+outputs:
+  download_dir:
+    type: Directory
+    outputBinding:
+      glob: "$(inputs.download_dir)"

--- a/demos/cwl_dag_modular_stage_out.cwl
+++ b/demos/cwl_dag_modular_stage_out.cwl
@@ -1,0 +1,47 @@
+cwlVersion: v1.2
+class: CommandLineTool
+
+baseCommand: ["UPLOAD"]
+
+requirements:
+  DockerRequirement:
+    dockerPull: ghcr.io/unity-sds/unity-data-services:9.1.0
+  NetworkAccess:
+    networkAccess: true
+  InitialWorkDirRequirement:
+    listing:
+    - entry: $(inputs.sample_output_data)
+      entryname: /tmp/outputs
+
+  EnvVarRequirement:
+    envDef:
+      STAGING_BUCKET: $(inputs.staging_bucket)
+      CATALOG_FILE: '/tmp/outputs/catalog.json'
+      LOG_LEVEL: '10'
+      PARALLEL_COUNT: '-1'
+      OUTPUT_DIRECTORY: $(runtime.outdir)
+      PROJECT: $(inputs.project)
+      VENUE: $(inputs.venue)
+
+      GRANULES_UPLOAD_TYPE: 'UPLOAD_S3_BY_STAC_CATALOG'
+      BASE_DIRECTORY: '/tmp/outputs'
+
+inputs:
+  project:
+    type: string
+  venue:
+    type: string
+  staging_bucket:
+    type: string
+  sample_output_data:
+    type: Directory
+
+outputs:
+  successful_features:
+    type: File
+    outputBinding:
+      glob: "$(runtime.outdir)/successful_features.json"
+  failed_features:
+    type: File
+    outputBinding:
+      glob: "$(runtime.outdir)/failed_features.json"


### PR DESCRIPTION
## Purpose

- Run stage in, process, and stage out CWL tasks in entrypoint file so that data is stored locally on EBS. This work covers the new stage in and stage out CWL workflows that point to updated Data Services container image.
- These are updated to set network access to true to enable downloading and uploading of data.

## Proposed Changes

- [ADD] Add CWL for stage in and stage out.

## Issues

- [#220 - Stage-In Task](https://github.com/unity-sds/unity-sps/issues/220)

## Testing

Deployed to `unity-venue-dev` for testing and confirmed CWL definitions work.