### PR TITLE
351 stage in unity

### DIFF
--- a/demos/cwl_dag_modular_stage_in.cwl
+++ b/demos/cwl_dag_modular_stage_in.cwl
@@ -5,14 +5,14 @@ baseCommand: ["DOWNLOAD"]
 
 requirements:
   DockerRequirement:
-    dockerPull: ghcr.io/unity-sds/unity-data-services:9.1.0
+    dockerPull: ghcr.io/unity-sds/unity-data-services:9.4.0
   NetworkAccess:
     networkAccess: true
   EnvVarRequirement:
     envDef:
       DOWNLOAD_DIR: $(runtime.outdir)/$(inputs.download_dir)
       STAC_JSON: $(inputs.stac_json)
-      LOG_LEVEL: '10'
+      LOG_LEVEL: $(inputs.log_level)
       PARALLEL_COUNT: '-1'
       DOWNLOAD_RETRY_WAIT_TIME: '30'
       DOWNLOAD_RETRY_TIMES: '5'
@@ -23,13 +23,31 @@ requirements:
       EDL_PASSWORD: '/sps/processing/workflows/edl_password'
       EDL_PASSWORD_TYPE: 'PARAM_STORE'
 
+      CLIENT_ID: $(inputs.unity_client_id)
+      COGNITO_URL: $(inputs.unity_cognito_url)
+      USERNAME: '/sps/processing/workflows/unity_username'
+      PASSWORD: '/sps/processing/workflows/unity_password'
+      PASSWORD_TYPE: 'PARAM_STORE'
+
       VERIFY_SSL: 'TRUE'
-      STAC_AUTH_TYPE: 'NONE'
+      STAC_AUTH_TYPE: $(inputs.stac_auth_type)
 
 inputs:
   download_dir:
     type: string
+  log_level:
+    default: '20'
+    type: string
+  stac_auth_type:
+    default: 'NONE'
+    type: string
   stac_json:
+    type: string
+  unity_client_id:
+    default: ''
+    type: string
+  unity_cognito_url:
+    default: 'https://cognito-idp.us-west-2.amazonaws.com'
     type: string
 
 outputs:

--- a/demos/cwl_dag_modular_stage_in.cwl
+++ b/demos/cwl_dag_modular_stage_in.cwl
@@ -5,7 +5,7 @@ baseCommand: ["DOWNLOAD"]
 
 requirements:
   DockerRequirement:
-    dockerPull: ghcr.io/unity-sds/unity-data-services:9.4.0
+    dockerPull: ghcr.io/unity-sds/unity-data-services:9.15.1
   NetworkAccess:
     networkAccess: true
   EnvVarRequirement:


### PR DESCRIPTION
## Purpose
- Includes both daac-hosted and unity-hosted STAC JSON authentication for DS Stage In task
## Proposed Changes
- [CHANGE] Stage In CWL to include unity-hosted STAC JSON and updated DS container version
## Issues
- N/A
## Testing
- Tested on existing DAAC-hosted granules. I do not have a STAC JSON that points to unity-hosted granules.
- Test: https://www.dev.mdps.mcp.nasa.gov:4443/nikki-4/dev/sps/dags/cwl_dag_modular/grid?dag_run_id=manual__2025-08-18T20%3A05%3A35%2B00%3A00&tab=logs&task_id=cwl_task_processing
